### PR TITLE
chore: switch deployment to gh-pages branch

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -19,6 +19,6 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: master
+          BRANCH: gh-pages
           FOLDER: public
           CLEAN: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ npm test
 
 ### CI/CD
 
-- **Build/Deploy** (`build-deploy.yml`): Runs on push to `main` branch - builds and deploys to GitHub Pages (master branch)
+- **Build/Deploy** (`build-deploy.yml`): Runs on push to `main` branch - builds and deploys to GitHub Pages (`gh-pages` branch)
 - **PR Check** (`pr-check.yml`): Runs on PRs to `main` - runs `format` and `build`
 
 ## Code Style Guidelines

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "develop": "gatsby develop",
     "format": "prettier --write '**/*.js'",
     "test": "jest",
-    "deploy": "gatsby build --prefix-paths && gh-pages -d public -b master"
+    "deploy": "gatsby build --prefix-paths && gh-pages -d public -b gh-pages"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",


### PR DESCRIPTION
## Summary
- Change deployment target from `master` to `gh-pages` branch
- Update `package.json` deploy script
- Update `build-deploy.yml` workflow
- Delete old `master` branch
- Delete feature branch from previous PR

## Action Required
**GitHub Pages source branch needs to be updated to `gh-pages` in repo settings:**
1. Go to repo **Settings** → **Pages**
2. Change **Source** from `master` to `gh-pages`
3. Save changes