### PR TITLE
chore: update portfolio content for HavocAI role

### DIFF
--- a/src/content/intro.md
+++ b/src/content/intro.md
@@ -7,14 +7,19 @@ Oh... I didn't see you there. It looks like you stumbled across my portfolio. Fe
 
 Here's what I work with:
 
-- **Backend**: Go, Python, Node.js, TypeScript
-- **Frontend**: React, Gatsby, Angular
-- **Cloud & Infrastructure**: AWS, GCP, Docker, Kubernetes
-- **Databases**: PostgreSQL, MongoDB, MySQL
-- **AI/ML**: TensorFlow, PyTorch, scikit-learn, RAG workflows, LLMs
+- **Cloud**: AWS, GCP, Azure, Lambda
+- **Containers & Orchestration**: Kubernetes, OpenShift, Docker, Helm
+- **Infrastructure as Code**: Pulumi, OpenTofu
+- **Observability**: CloudWatch, CloudTrail, Grafana, Prometheus, VictoriaMetrics
+- **Networking**: Cloudflare, Tailscale, Edge Computing, MQTT
+- **AI/ML**: TensorFlow, PyTorch, scikit-learn, MLflow
 - **AI Agents**: Claude Code, Codex, OpenCode, Ollama, MCP
-- **DevOps**: GitHub Actions, CI/CD, Infrastructure as Code
-- **Security**: AppSec, SAST/DAST tools, vulnerability scanning
+- **Backend**: Go, Python, Node.js, TypeScript
+- **DevOps**: GitHub Actions, Balena, CI/CD
+- **Security**: AppSec, Snyk, Aqua, Semgrep, Burp, SAST/DAST, vulnerability scanning
+- **Databases**: PostgreSQL, MongoDB, MySQL
+- **Frontend**: React, Gatsby, Angular, Vue, Next.js
+- **Hardware**: Custom PCs, Home Lab, Game Hosting, Raspberry Pi
 
 I've been diving deep into agentic AI programming lately, leveraging AI coding agents to accelerate development, automate repetitive tasks, and explore new ways of building software. Running local LLMs with Ollama and pairing with tools like Claude Code has been a blast. The future of development is collaborative: human intuition paired with AI agents.
 

--- a/src/content/projects/havocai.md
+++ b/src/content/projects/havocai.md
@@ -10,50 +10,63 @@ tags:
   - Go
   - Python
   - TypeScript
-  - AI/ML
+  - Helm
+  - Pulumi
+  - OpenTofu
   - DevOps
   - Security
-  - IoT
-  - MLOps
+  - CI/CD
+  - Platform Engineering
 ---
 
 ## Overview
 
-HavocAI is building autonomous vessels, including 100-foot robot boats, for sea, air, and land operations. I lead the cloud infrastructure that powers these systems.
+HavocAI is building collaborative autonomy technologies for sea, air, and land operations. The company develops autonomous surface vessels and the software stack that enables a single human operator to command thousands of autonomous assets.
 
 ## Role
 
-As a Senior Platform Engineer, I work on the cloud platform team responsible for:
+As a Senior Platform Engineer on a two-person team (both senior level), I own the cloud infrastructure that the entire company runs on. I am responsible for:
 
-- Building and maintaining backend services that communicate with vessels
-- Developing AI/ML infrastructure for autonomous navigation
-- Creating edge/cloud integration pipelines
-- Ensuring production reliability for systems operating at sea
+- All AWS infrastructure and architecture
+- Kubernetes clusters and deployments
+- Helm charts for all services - managing all internal and external Helm charts deployed across the entire company
+- Automation and CI/CD pipelines
+- Security hardening and compliance
+- Running release trains for the entire software stack to internal and external users
 
 ## Tech Stack
 
 - **Backend**: Go, Python, TypeScript
-- **Cloud**: AWS (IAM, VPC, EC2, EKS, S3)
-- **Infrastructure**: Kubernetes, Docker, OpenTofu, Pulumi, GitOps
-- **AI/ML**: MLflow, Auto-labeling, MLOps
-- **IoT**: Distributed async, edge computing
+- **Cloud**: AWS (IAM, VPC, EC2, EKS, S3, Lambda, CodeBuild, CloudWatch, CloudTrail, Cost Management)
+- **Infrastructure**: Kubernetes, Helm, Docker, Pulumi, OpenTofu
+- **Observability**: Grafana, Prometheus, VictoriaMetrics
+- **CI/CD**: GitHub Actions, Balena, GitOps
+- **Security**: AWS Security Hub, Vault, hardening
 
 ## Key Projects
 
-### Vessel Communication Platform
+### Platform Foundation
 
-Built real-time communication layer between shore-based operations and autonomous vessels. Handles telemetry data, command/control signals, and mission planning.
+Currently owning and expanding the cloud platform with my team. Everything at HavocAI runs on infrastructure I design, deploy, and maintain.
 
-### AI/ML Pipeline
+### Release Trains
 
-Designed and implemented ML training and inference pipelines for navigation models. Integrated with edge devices on vessels for real-time decision making.
+Implemented and run automated release trains delivering the entire software stack to internal and external users on a regular cadence.
 
-### Edge-Cloud Integration
+### Helm Chart Management
 
-Developed robust connectivity solutions for intermittent network conditions at sea. Implemented offline-first patterns and intelligent data synchronization.
+Manage all internal and external Helm charts deployed across the entire company. Own the chart library and ensure consistency across all services.
+
+### Security & Compliance
+
+Implemented security hardening across all infrastructure. Built automated security scanning and compliance checks.
+
+### Multi-Environment Deployments
+
+Designed and maintain deployments across development, staging, and production environments with proper separation and security controls.
 
 ## Impact
 
-- Leading infrastructure for next-generation autonomous maritime systems
-- Building systems that must operate reliably in harsh marine environments
-- Bridging cutting-edge AI research with production systems
+- Currently owning the platform that supports 160+ internal employees, partners, and customers
+- Enable autonomous maritime operations through reliable, secure cloud infrastructure
+- Deliver releases at company scale with minimal manual intervention

--- a/src/content/work.md
+++ b/src/content/work.md
@@ -9,17 +9,20 @@ title: 'Work'
 
 **[HavocAI](/projects/havocai)** - Senior Platform Engineer
 
-Working on the cloud platform for a maritime autonomy company building autonomous vessels and collaborative AI systems for sea, air, and land operations. HavocAI is developing cutting-edge autonomous boat technology, including 100-foot robot vessels, and I lead the cloud infrastructure that powers these systems.
+Currently owning the cloud platform on a small but growing team supporting all internal employees, partners, and customers. Owns all company infrastructure - from AWS and Kubernetes to Helm charts, automation, and security. Manages all internal and external Helm charts deployed across the company. Runs release trains for the entire software stack to internal and external users.
 
 <span class="tech-tags">
 <span class="tag">AWS</span>
 <span class="tag">Kubernetes</span>
+<span class="tag">Helm</span>
+<span class="tag">Pulumi</span>
+<span class="tag">OpenTofu</span>
 <span class="tag">Go</span>
 <span class="tag">Python</span>
 <span class="tag">TypeScript</span>
-<span class="tag">AI/ML</span>
 <span class="tag">DevOps</span>
 <span class="tag">Security</span>
+<span class="tag">CI/CD</span>
 </span>
 
 ---


### PR DESCRIPTION
## Summary
- Update HavocAI role description to reflect current responsibilities
- Add Pulumi, OpenTofu, Helm, Balena to tech stack
- Reorganize intro tech stack with Cloud, Containers, IaC, Observability, Networking
- Add Grafana, Prometheus, VictoriaMetrics to observability
- Add MLflow to AI/ML
- Reorganize security tools (Snyk, Aqua, Semgrep, Burp)
- Add hardware/home lab to tech stack
- Update to "currently owning" platform on small but growing team