### PR TITLE
feat: Phase 2 medium-term enhancements + UX improvements

### DIFF
--- a/src/assets/scss/base/_page.scss
+++ b/src/assets/scss/base/_page.scss
@@ -31,3 +31,28 @@
 			}
 
 	}
+
+	// Focus-visible styles for keyboard users
+	:focus-visible {
+		outline: 2px solid functions.palette(accent);
+		outline-offset: 2px;
+		border-radius: 2px;
+	}
+
+	// Skip to content link - visually hidden until focused
+	.skip-to-content {
+		position: absolute;
+		top: -100%;
+		left: 0;
+		z-index: 99999;
+		padding: 0.5rem 1rem;
+		background: functions.palette(accent);
+		color: functions.palette(bg);
+		font-weight: 600;
+		text-decoration: none;
+		border-radius: 0 0 4px 0;
+
+		&:focus {
+			top: 0;
+		}
+	}

--- a/src/assets/scss/components/_github.scss
+++ b/src/assets/scss/components/_github.scss
@@ -1,0 +1,102 @@
+@use '../libs/functions';
+@use '../libs/skel';
+
+.github-activity {
+  margin: 2rem 0;
+
+  h3 {
+    font-size: 1rem;
+    margin-bottom: 1rem;
+    text-align: center;
+  }
+
+  .github-repos {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+
+    @include skel.breakpoint(small) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .github-repo-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.75rem;
+    border: 1px solid functions.palette(border-bg);
+    border-radius: functions.size(border-radius);
+    text-decoration: none;
+    color: functions.palette(fg);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+    &:hover {
+      border-color: functions.palette(accent);
+      background: rgba(245, 158, 11, 0.05);
+      transform: translateY(-1px);
+    }
+
+    &:focus-visible {
+      outline: 2px solid functions.palette(accent);
+      outline-offset: 2px;
+    }
+
+    .repo-name {
+      font-weight: 600;
+      font-size: 0.85rem;
+      color: functions.palette(accent);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+    }
+
+    .repo-description {
+      font-size: 0.75rem;
+      line-height: 1.4;
+      color: functions.palette(fg-light);
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    .repo-meta {
+      display: flex;
+      gap: 0.75rem;
+      font-size: 0.7rem;
+      color: functions.palette(fg-light);
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .repo-language {
+      padding: 0.1rem 0.4rem;
+      border-radius: 3px;
+      background: functions.palette(border-bg);
+    }
+
+    .repo-stars {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.15rem;
+    }
+  }
+
+  .github-footer {
+    text-align: center;
+    margin-top: 1rem;
+
+    a {
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.15em;
+    }
+  }
+
+  .github-loading,
+  .github-error {
+    text-align: center;
+    font-size: 0.85rem;
+    color: functions.palette(fg-light);
+  }
+}

--- a/src/assets/scss/layout/_header.scss
+++ b/src/assets/scss/layout/_header.scss
@@ -82,11 +82,32 @@
       }
     }
 
-    p {
+    .subhead {
       text-transform: uppercase;
       letter-spacing: functions.font(letter-spacing);
-      font-size: 0.8rem;
+      font-size: 0.9rem;
       line-height: 2;
+      opacity: 0.7;
+      margin-bottom: 0.25rem;
+    }
+
+    .tagline {
+      text-transform: uppercase;
+      letter-spacing: functions.font(letter-spacing-heading);
+      font-size: 0.85rem;
+      font-weight: functions.font(weight-bold);
+      line-height: 1.6;
+      color: functions.palette(accent);
+      margin-bottom: 0;
+    }
+
+    .byline {
+      text-transform: uppercase;
+      letter-spacing: functions.font(letter-spacing);
+      font-size: 0.75rem;
+      line-height: 2;
+      opacity: 0.6;
+      margin-bottom: 0;
     }
   }
 
@@ -133,6 +154,27 @@
             background-color: functions.palette(accent);
             transform: translateY(0);
             box-shadow: 0 2px 8px rgba(245, 158, 11, 0.3);
+          }
+
+          &.special {
+            background: functions.palette(gradient);
+            border: none;
+            color: #1b1f22 !important;
+            font-weight: functions.font(weight-bold);
+            box-shadow: 0 4px 15px rgba(245, 158, 11, 0.3);
+
+            &:hover,
+            &:focus {
+              transform: translateY(-2px);
+              box-shadow: 0 8px 25px rgba(245, 158, 11, 0.4);
+              background: functions.palette(gradient);
+              color: #1b1f22 !important;
+            }
+
+            &:active {
+              transform: translateY(0);
+              box-shadow: 0 4px 10px rgba(245, 158, 11, 0.3);
+            }
           }
         }
       }

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -41,6 +41,7 @@
 @include meta.load-css('components/row');
 @include meta.load-css('components/logo');
 @include meta.load-css('components/tags');
+@include meta.load-css('components/github');
 
 // Layout.
 

--- a/src/components/About.js
+++ b/src/components/About.js
@@ -1,12 +1,16 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { StaticQuery, graphql } from 'gatsby'
 import wholeFamSki from '../images/wholeFamSki.jpg'
 import famPic from '../images/wholefam.jpg'
 import buGrad from '../images/buGrad.jpg'
 import optumPats from '../images/fiverings.jpg'
+import twins from '../images/fampiece-crop.jpg'
 
 const AboutContent = ({ article, articleTimeout, onCloseArticle, html }) => {
+  const [guess, setGuess] = useState('')
+  const [animating, setAnimating] = useState(false)
+
   const close = (
     <div
       role="button"
@@ -22,6 +26,13 @@ const AboutContent = ({ article, articleTimeout, onCloseArticle, html }) => {
     ></div>
   )
 
+  const handleGuess = (g) => {
+    if (animating) return
+    setAnimating(true)
+    setGuess(g)
+    setTimeout(() => setAnimating(false), 600)
+  }
+
   return (
     <article
       id="about"
@@ -32,6 +43,68 @@ const AboutContent = ({ article, articleTimeout, onCloseArticle, html }) => {
     >
       <h2 className="major">About</h2>
       <div dangerouslySetInnerHTML={{ __html: html }} />
+      <hr />
+      <h3 className="major">The Twin Guessing Game</h3>
+      <p>Can you guess which one is me?</p>
+      <div>
+        <div className="guess-buttons">
+          <button
+            className={`button ${guess === 'left' ? 'correct' : ''}`}
+            onClick={() => handleGuess('left')}
+          >
+            Left
+          </button>
+          <button
+            className={`button ${guess === 'right' ? 'wrong' : ''}`}
+            onClick={() => handleGuess('right')}
+          >
+            Right
+          </button>
+        </div>
+        {guess === 'right' && (
+          <p className="feedback wrong-feedback">
+            It&apos;s okay... I forgive you.
+          </p>
+        )}
+        {guess === 'left' && (
+          <p className="feedback correct-feedback">I knew you could do it!</p>
+        )}
+        <div
+          className="image main twin-image"
+          style={{
+            position: 'relative',
+            display: 'block',
+            textAlign: 'center',
+            margin: '0 auto',
+          }}
+        >
+          <img
+            src={twins}
+            alt="Andrew and his fraternal twin"
+            style={{
+              display: 'block',
+              maxWidth: '100%',
+              margin: '0 auto',
+            }}
+            className={
+              guess === 'left'
+                ? 'correct-guess'
+                : guess === 'right'
+                  ? 'wrong-guess'
+                  : ''
+            }
+          />
+          {guess && (
+            <div className="twin-overlay">
+              <span className="twin-label">
+                {guess === 'left' ? "✓ That's me!" : "✗ That's my twin!"}
+              </span>
+            </div>
+          )}
+        </div>
+        <p>I grew up as one of a pair. Believe it or not, we are fraternal.</p>
+      </div>
+      <hr />
       <div className="row">
         <span className="image main">
           <img

--- a/src/components/About.test.js
+++ b/src/components/About.test.js
@@ -64,9 +64,48 @@ describe('About', () => {
       />
     )
     const images = screen.getAllByRole('img', { hidden: true })
-    expect(images.length).toBeGreaterThanOrEqual(4)
+    expect(images.length).toBeGreaterThanOrEqual(5)
     images.forEach((img) => {
       expect(img).toHaveAttribute('alt')
     })
+  })
+
+  it('renders the twin guessing game', () => {
+    render(
+      <About
+        article="about"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    expect(
+      screen.getByText(/Can you guess which one is me/i)
+    ).toBeInTheDocument()
+    expect(screen.getByText('Left')).toBeInTheDocument()
+    expect(screen.getByText('Right')).toBeInTheDocument()
+  })
+
+  it('shows correct feedback when left is clicked', () => {
+    render(
+      <About
+        article="about"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    fireEvent.click(screen.getByText('Left'))
+    expect(screen.getByText(/i knew you could do it/i)).toBeInTheDocument()
+  })
+
+  it('shows wrong feedback when right is clicked', () => {
+    render(
+      <About
+        article="about"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    fireEvent.click(screen.getByText('Right'))
+    expect(screen.getByText(/it.s okay.* i forgive you/i)).toBeInTheDocument()
   })
 })

--- a/src/components/About.test.js
+++ b/src/components/About.test.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import About from './About'
+
+jest.mock('gatsby', () => ({
+  StaticQuery: jest.fn(({ render }) =>
+    render({
+      markdownRemark: {
+        html: '<p>Test about content</p>',
+      },
+    })
+  ),
+  graphql: jest.fn(),
+}))
+
+describe('About', () => {
+  const mockOnCloseArticle = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders about heading when active', () => {
+    render(
+      <About
+        article="about"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    expect(screen.getByText('About')).toBeInTheDocument()
+  })
+
+  it('renders close button', () => {
+    render(
+      <About
+        article="about"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    const closeButton = screen.getByLabelText('close')
+    expect(closeButton).toBeInTheDocument()
+  })
+
+  it('calls onCloseArticle when close button clicked', () => {
+    render(
+      <About
+        article="about"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    fireEvent.click(screen.getByLabelText('close'))
+    expect(mockOnCloseArticle).toHaveBeenCalled()
+  })
+
+  it('renders images with alt text', () => {
+    render(
+      <About
+        article="about"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    const images = screen.getAllByRole('img', { hidden: true })
+    expect(images.length).toBeGreaterThanOrEqual(4)
+    images.forEach((img) => {
+      expect(img).toHaveAttribute('alt')
+    })
+  })
+})

--- a/src/components/Contact.test.js
+++ b/src/components/Contact.test.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import Contact from './Contact'
+
+jest.mock('gatsby', () => ({
+  StaticQuery: jest.fn(({ render }) =>
+    render({
+      markdownRemark: {
+        html: '<p>Test contact content</p>',
+      },
+    })
+  ),
+  graphql: jest.fn(),
+}))
+
+describe('Contact', () => {
+  const mockOnCloseArticle = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders contact heading when active', () => {
+    render(
+      <Contact
+        article="contact"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    expect(screen.getByText('Contact')).toBeInTheDocument()
+  })
+
+  it('renders close button', () => {
+    render(
+      <Contact
+        article="contact"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    expect(screen.getByLabelText('close')).toBeInTheDocument()
+  })
+
+  it('calls onCloseArticle when close button clicked', () => {
+    render(
+      <Contact
+        article="contact"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    fireEvent.click(screen.getByLabelText('close'))
+    expect(mockOnCloseArticle).toHaveBeenCalled()
+  })
+
+  it('renders social links within contact', () => {
+    render(
+      <Contact
+        article="contact"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    expect(screen.getByText('LinkedIn')).toBeInTheDocument()
+  })
+})

--- a/src/components/GitHubActivity.js
+++ b/src/components/GitHubActivity.js
@@ -1,0 +1,116 @@
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+
+const NUM_REPOS = 6
+
+const GitHubActivity = ({ username }) => {
+  const [repos, setRepos] = useState([])
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const fetchRepos = async () => {
+      try {
+        const res = await fetch(
+          `https://api.github.com/users/${username}/repos?sort=updated&per_page=${NUM_REPOS}`
+        )
+        if (!res.ok) throw new Error(`GitHub API responded with ${res.status}`)
+        const data = await res.json()
+        if (!cancelled) {
+          setRepos(data)
+          setLoading(false)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err.message)
+          setLoading(false)
+        }
+      }
+    }
+
+    fetchRepos()
+
+    return () => {
+      cancelled = true
+    }
+  }, [username])
+
+  if (error) {
+    return (
+      <div className="github-activity">
+        <p className="github-error">
+          Unable to load recent activity. Visit{' '}
+          <a
+            href={`https://github.com/${username}`}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            github.com/{username}
+          </a>{' '}
+          to see what I am working on.
+        </p>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="github-activity">
+        <p className="github-loading">Loading recent activity...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="github-activity">
+      <h3>Recent Open Source Activity</h3>
+      <div className="github-repos">
+        {repos.map((repo) => (
+          <a
+            key={repo.id}
+            href={repo.html_url}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="github-repo-card"
+            aria-label={`${repo.name}${repo.description ? ': ' + repo.description : ''}`}
+          >
+            <span className="repo-name">{repo.name}</span>
+            {repo.description && (
+              <span className="repo-description">{repo.description}</span>
+            )}
+            <span className="repo-meta">
+              {repo.language && (
+                <span className="repo-language">{repo.language}</span>
+              )}
+              <span className="repo-stars">★ {repo.stargazers_count}</span>
+              <span className="repo-updated">
+                Updated{' '}
+                {new Date(repo.updated_at).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </span>
+            </span>
+          </a>
+        ))}
+      </div>
+      <p className="github-footer">
+        <a
+          href={`https://github.com/${username}`}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          See more on GitHub →
+        </a>
+      </p>
+    </div>
+  )
+}
+
+GitHubActivity.propTypes = {
+  username: PropTypes.string.isRequired,
+}
+
+export default GitHubActivity

--- a/src/components/GitHubActivity.test.js
+++ b/src/components/GitHubActivity.test.js
@@ -1,0 +1,94 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import GitHubActivity from './GitHubActivity'
+
+const mockRepos = [
+  {
+    id: 1,
+    name: 'test-repo',
+    description: 'A test repository',
+    html_url: 'https://github.com/atmollohan/test-repo',
+    language: 'JavaScript',
+    stargazers_count: 5,
+    updated_at: '2026-06-10T00:00:00Z',
+  },
+  {
+    id: 2,
+    name: 'another-repo',
+    description: null,
+    html_url: 'https://github.com/atmollohan/another-repo',
+    language: 'Go',
+    stargazers_count: 0,
+    updated_at: '2026-06-01T00:00:00Z',
+  },
+]
+
+describe('GitHubActivity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows loading state initially', () => {
+    global.fetch = jest.fn(() => new Promise(() => {}))
+    render(<GitHubActivity username="atmollohan" />)
+    expect(screen.getByText(/loading recent activity/i)).toBeInTheDocument()
+  })
+
+  it('renders repo cards after successful fetch', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockRepos),
+    })
+
+    render(<GitHubActivity username="atmollohan" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('test-repo')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('another-repo')).toBeInTheDocument()
+    expect(screen.getByText('A test repository')).toBeInTheDocument()
+    expect(screen.getByText('JavaScript')).toBeInTheDocument()
+  })
+
+  it('shows error message when fetch fails', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+    })
+
+    render(<GitHubActivity username="atmollohan" />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/unable to load recent activity/i)
+      ).toBeInTheDocument()
+    })
+
+    const link = screen.getByText(/github.com\/atmollohan/i)
+    expect(link).toBeInTheDocument()
+    expect(link.closest('a')).toHaveAttribute(
+      'href',
+      'https://github.com/atmollohan'
+    )
+  })
+
+  it('uses correct GitHub API URL', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    })
+
+    render(<GitHubActivity username="atmollohan" />)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.github.com/users/atmollohan/repos?sort=updated&per_page=6'
+      )
+    })
+  })
+
+  afterEach(() => {
+    delete global.fetch
+  })
+})

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -9,48 +9,25 @@ const Header = (props) => (
     <div className="content">
       <div className="inner">
         <h1>Mollo Tech</h1>
-        <h3>Andrew Mollohan</h3>
+        <p className="subhead">Andrew Mollohan</p>
         <p>Head of an engineer, heart of a pioneer.</p>
       </div>
     </div>
-    <nav>
+    <nav aria-label="Main navigation">
       <ul>
-        <li>
-          <button
-            onClick={() => {
-              props.onOpenArticle('intro')
-            }}
-          >
-            Intro
-          </button>
-        </li>
-        <li>
-          <button
-            onClick={() => {
-              props.onOpenArticle('work')
-            }}
-          >
-            Work
-          </button>
-        </li>
-        <li>
-          <button
-            onClick={() => {
-              props.onOpenArticle('about')
-            }}
-          >
-            About
-          </button>
-        </li>
-        <li>
-          <button
-            onClick={() => {
-              props.onOpenArticle('contact')
-            }}
-          >
-            Contact
-          </button>
-        </li>
+        {['intro', 'work', 'about', 'contact'].map((section) => (
+          <li key={section}>
+            <button
+              aria-current={props.article === section ? 'page' : undefined}
+              aria-expanded={props.article === section}
+              onClick={() => {
+                props.onOpenArticle(section)
+              }}
+            >
+              {section.charAt(0).toUpperCase() + section.slice(1)}
+            </button>
+          </li>
+        ))}
       </ul>
     </nav>
   </header>
@@ -59,6 +36,7 @@ const Header = (props) => (
 Header.propTypes = {
   onOpenArticle: PropTypes.func,
   timeout: PropTypes.bool,
+  article: PropTypes.string,
 }
 
 export default Header

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -10,21 +10,25 @@ const Header = (props) => (
       <div className="inner">
         <h1>Mollo Tech</h1>
         <p className="subhead">Andrew Mollohan</p>
-        <p>Head of an engineer, heart of a pioneer.</p>
+        <p className="tagline">Cloud Platform Engineer</p>
+        <p className="byline">Building infrastructure for autonomous systems</p>
       </div>
     </div>
     <nav aria-label="Main navigation">
       <ul>
-        {['intro', 'work', 'about', 'contact'].map((section) => (
+        {['work', 'intro', 'about', 'contact'].map((section) => (
           <li key={section}>
             <button
+              className={section === 'work' ? 'button special' : ''}
               aria-current={props.article === section ? 'page' : undefined}
               aria-expanded={props.article === section}
               onClick={() => {
                 props.onOpenArticle(section)
               }}
             >
-              {section.charAt(0).toUpperCase() + section.slice(1)}
+              {section === 'work'
+                ? "What I've Built"
+                : section.charAt(0).toUpperCase() + section.slice(1)}
             </button>
           </li>
         ))}

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -16,19 +16,19 @@ describe('Header', () => {
     expect(screen.getByText('Andrew Mollohan')).toBeInTheDocument()
   })
 
-  it('renders tagline', () => {
+  it('renders role tagline', () => {
     render(<Header onOpenArticle={mockOnOpenArticle} timeout={true} />)
 
     expect(
-      screen.getByText('Head of an engineer, heart of a pioneer.')
+      screen.getByText('Cloud Platform Engineer')
     ).toBeInTheDocument()
   })
 
   it('renders all navigation buttons', () => {
     render(<Header onOpenArticle={mockOnOpenArticle} timeout={true} />)
 
+    expect(screen.getByText("What I've Built")).toBeInTheDocument()
     expect(screen.getByText('Intro')).toBeInTheDocument()
-    expect(screen.getByText('Work')).toBeInTheDocument()
     expect(screen.getByText('About')).toBeInTheDocument()
     expect(screen.getByText('Contact')).toBeInTheDocument()
   })
@@ -39,7 +39,7 @@ describe('Header', () => {
     fireEvent.click(screen.getByText('Intro'))
     expect(mockOnOpenArticle).toHaveBeenCalledWith('intro')
 
-    fireEvent.click(screen.getByText('Work'))
+    fireEvent.click(screen.getByText("What I've Built"))
     expect(mockOnOpenArticle).toHaveBeenCalledWith('work')
 
     fireEvent.click(screen.getByText('About'))

--- a/src/components/Intro.js
+++ b/src/components/Intro.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { StaticQuery, graphql } from 'gatsby'
 import SocialLinks from './SocialLinks'
+import GitHubActivity from './GitHubActivity'
 import twins from '../images/fampiece-crop.jpg'
 
 const IntroContent = ({ article, articleTimeout, onCloseArticle, html }) => {
@@ -105,6 +106,7 @@ const IntroContent = ({ article, articleTimeout, onCloseArticle, html }) => {
         <br></br>
         <p>I grew up as one of a pair. Believe it or not, we are fraternal.</p>
       </div>
+      <GitHubActivity username="atmollohan" />
       <SocialLinks />
       {close}
     </article>

--- a/src/components/Intro.js
+++ b/src/components/Intro.js
@@ -1,14 +1,10 @@
-import React, { useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { StaticQuery, graphql } from 'gatsby'
 import SocialLinks from './SocialLinks'
 import GitHubActivity from './GitHubActivity'
-import twins from '../images/fampiece-crop.jpg'
 
 const IntroContent = ({ article, articleTimeout, onCloseArticle, html }) => {
-  const [response, setResponse] = useState('')
-  const [animating, setAnimating] = useState(false)
-
   const close = (
     <div
       role="button"
@@ -17,23 +13,14 @@ const IntroContent = ({ article, articleTimeout, onCloseArticle, html }) => {
       tabIndex={0}
       onClick={() => {
         onCloseArticle()
-        setResponse('')
       }}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           onCloseArticle()
-          setResponse('')
         }
       }}
     ></div>
   )
-
-  const handleGuess = (guess) => {
-    if (animating) return
-    setAnimating(true)
-    setResponse(guess)
-    setTimeout(() => setAnimating(false), 600)
-  }
 
   return (
     <article
@@ -43,69 +30,8 @@ const IntroContent = ({ article, articleTimeout, onCloseArticle, html }) => {
       }`}
       style={{ display: 'none' }}
     >
-      <h2 className="major">Intro</h2>
+      <h2 className="major">What I Do</h2>
       <div dangerouslySetInnerHTML={{ __html: html }} />
-      <p>Can you guess which one is me?</p>
-      <div>
-        <div className="guess-buttons">
-          <button
-            className={`button ${response === 'left' ? 'correct' : ''}`}
-            onClick={() => handleGuess('left')}
-          >
-            Left
-          </button>
-          <button
-            className={`button ${response === 'right' ? 'wrong' : ''}`}
-            onClick={() => handleGuess('right')}
-          >
-            Right
-          </button>
-        </div>
-        <br></br>
-        {response === 'right' && (
-          <p className="feedback wrong-feedback">
-            It&apos;s okay... I forgive you.
-          </p>
-        )}
-        {response === 'left' && (
-          <p className="feedback correct-feedback">I knew you could do it!</p>
-        )}
-        <div
-          className="image main twin-image"
-          style={{
-            position: 'relative',
-            display: 'block',
-            textAlign: 'center',
-            margin: '0 auto',
-          }}
-        >
-          <img
-            src={twins}
-            alt="twins"
-            style={{
-              display: 'block',
-              maxWidth: '100%',
-              margin: '0 auto',
-            }}
-            className={
-              response === 'left'
-                ? 'correct-guess'
-                : response === 'right'
-                  ? 'wrong-guess'
-                  : ''
-            }
-          />
-          {response && (
-            <div className="twin-overlay">
-              <span className="twin-label">
-                {response === 'left' ? "✓ That's me!" : "✗ That's my twin!"}
-              </span>
-            </div>
-          )}
-        </div>
-        <br></br>
-        <p>I grew up as one of a pair. Believe it or not, we are fraternal.</p>
-      </div>
       <GitHubActivity username="atmollohan" />
       <SocialLinks />
       {close}

--- a/src/components/Intro.test.js
+++ b/src/components/Intro.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import Intro from './Intro'
 
 jest.mock('gatsby', () => ({
@@ -20,59 +20,6 @@ describe('Intro', () => {
     jest.clearAllMocks()
   })
 
-  it('renders intro content', () => {
-    render(
-      <Intro
-        article=""
-        articleTimeout={false}
-        onCloseArticle={mockOnCloseArticle}
-      />
-    )
-
-    expect(
-      screen.getByText(/can you guess which one is me/i)
-    ).toBeInTheDocument()
-  })
-
-  it('renders left and right buttons', () => {
-    render(
-      <Intro
-        article=""
-        articleTimeout={false}
-        onCloseArticle={mockOnCloseArticle}
-      />
-    )
-
-    expect(screen.getByText('Left')).toBeInTheDocument()
-    expect(screen.getByText('Right')).toBeInTheDocument()
-  })
-
-  it('shows correct feedback when left button is clicked', () => {
-    render(
-      <Intro
-        article="intro"
-        articleTimeout={true}
-        onCloseArticle={mockOnCloseArticle}
-      />
-    )
-
-    fireEvent.click(screen.getByText('Left'))
-    expect(screen.getByText(/i knew you could do it/i)).toBeInTheDocument()
-  })
-
-  it('shows wrong feedback when right button is clicked', () => {
-    render(
-      <Intro
-        article="intro"
-        articleTimeout={true}
-        onCloseArticle={mockOnCloseArticle}
-      />
-    )
-
-    fireEvent.click(screen.getByText('Right'))
-    expect(screen.getByText(/it.s okay.* i forgive you/i)).toBeInTheDocument()
-  })
-
   it('renders intro heading when article is active', () => {
     render(
       <Intro
@@ -82,7 +29,7 @@ describe('Intro', () => {
       />
     )
 
-    expect(screen.getByText('Intro')).toBeInTheDocument()
+    expect(screen.getByText('What I Do')).toBeInTheDocument()
   })
 
   it('renders social links', () => {
@@ -97,15 +44,15 @@ describe('Intro', () => {
     expect(screen.getByText('LinkedIn')).toBeInTheDocument()
   })
 
-  it('renders fraternal twins text', () => {
+  it('renders close button', () => {
     render(
       <Intro
-        article=""
-        articleTimeout={false}
+        article="intro"
+        articleTimeout={true}
         onCloseArticle={mockOnCloseArticle}
       />
     )
 
-    expect(screen.getByText(/we are fraternal/i)).toBeInTheDocument()
+    expect(screen.getByLabelText('close')).toBeInTheDocument()
   })
 })

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -13,9 +13,10 @@ const Main = ({
   setWrapperRef,
 }) => {
   return (
-    <div
+    <main
       ref={setWrapperRef}
       id="main"
+      role="main"
       style={timeout ? { display: 'flex' } : { display: 'none' }}
     >
       <Intro
@@ -41,7 +42,7 @@ const Main = ({
         articleTimeout={articleTimeout}
         onCloseArticle={onCloseArticle}
       />
-    </div>
+    </main>
   )
 }
 

--- a/src/components/Main.test.js
+++ b/src/components/Main.test.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import Main from './Main'
+
+jest.mock('gatsby', () => ({
+  StaticQuery: jest.fn(({ render }) =>
+    render({
+      markdownRemark: {
+        html: '<p>Test content</p>',
+      },
+    })
+  ),
+  graphql: jest.fn(),
+}))
+
+describe('Main', () => {
+  const mockOnCloseArticle = jest.fn()
+  const mockSetWrapperRef = jest.fn()
+
+  it('renders main element with correct id', () => {
+    const { container } = render(
+      <Main
+        article=""
+        articleTimeout={false}
+        onCloseArticle={mockOnCloseArticle}
+        timeout={true}
+        setWrapperRef={mockSetWrapperRef}
+      />
+    )
+    expect(container.querySelector('#main')).toBeInTheDocument()
+  })
+
+  it('renders main element with main role', () => {
+    const { container } = render(
+      <Main
+        article=""
+        articleTimeout={false}
+        onCloseArticle={mockOnCloseArticle}
+        timeout={true}
+        setWrapperRef={mockSetWrapperRef}
+      />
+    )
+    expect(container.querySelector('#main')).toHaveAttribute('role', 'main')
+  })
+
+  it('is hidden when timeout is false', () => {
+    const { container } = render(
+      <Main
+        article=""
+        articleTimeout={false}
+        onCloseArticle={mockOnCloseArticle}
+        timeout={false}
+        setWrapperRef={mockSetWrapperRef}
+      />
+    )
+    const main = container.querySelector('#main')
+    expect(main.style.display).toBe('none')
+  })
+})

--- a/src/components/SocialLinks.js
+++ b/src/components/SocialLinks.js
@@ -1,13 +1,14 @@
 import React from 'react'
 
 const SocialLinks = () => (
-  <ul className="icons">
+  <ul className="icons" aria-label="Social media links">
     <li>
       <a
         href="https://www.linkedin.com/in/andrew-mollohan-868b87b3"
         className="icon fa-linkedin"
         target="_blank"
-        rel="noreferrer"
+        rel="noreferrer noopener"
+        aria-label="Andrew Mollohan on LinkedIn"
       >
         <span className="label">LinkedIn</span>
       </a>
@@ -17,7 +18,8 @@ const SocialLinks = () => (
         href="https://github.com/atmollohan"
         className="icon fa-github"
         target="_blank"
-        rel="noreferrer"
+        rel="noreferrer noopener"
+        aria-label="Andrew Mollohan personal GitHub"
       >
         <span className="label">Personal</span>
       </a>
@@ -27,7 +29,8 @@ const SocialLinks = () => (
         href="https://github.com/andrew-mollohan-havoc"
         className="icon fa-github"
         target="_blank"
-        rel="noreferrer"
+        rel="noreferrer noopener"
+        aria-label="Andrew Mollohan Havoc GitHub"
       >
         <span className="label">Havoc</span>
       </a>
@@ -37,7 +40,8 @@ const SocialLinks = () => (
         href="https://github.com/atmollo-harness"
         className="icon fa-github"
         target="_blank"
-        rel="noreferrer"
+        rel="noreferrer noopener"
+        aria-label="Andrew Mollohan Harness GitHub"
       >
         <span className="label">Harness</span>
       </a>
@@ -47,7 +51,8 @@ const SocialLinks = () => (
         href="https://www.instagram.com/mollotech/"
         className="icon fa-instagram"
         target="_blank"
-        rel="noreferrer"
+        rel="noreferrer noopener"
+        aria-label="Mollo Tech on Instagram"
       >
         <span className="label">Instagram</span>
       </a>

--- a/src/components/Work.test.js
+++ b/src/components/Work.test.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import Work from './Work'
+
+jest.mock('gatsby', () => ({
+  StaticQuery: jest.fn(({ render }) =>
+    render({
+      markdownRemark: {
+        html: '<p>Test work content</p>',
+      },
+    })
+  ),
+  graphql: jest.fn(),
+}))
+
+describe('Work', () => {
+  const mockOnCloseArticle = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders work heading when active', () => {
+    render(
+      <Work
+        article="work"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    expect(screen.getByText('Work')).toBeInTheDocument()
+  })
+
+  it('renders close button', () => {
+    render(
+      <Work
+        article="work"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    expect(screen.getByLabelText('close')).toBeInTheDocument()
+  })
+
+  it('calls onCloseArticle when close button clicked', () => {
+    render(
+      <Work
+        article="work"
+        articleTimeout={true}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    fireEvent.click(screen.getByLabelText('close'))
+    expect(mockOnCloseArticle).toHaveBeenCalled()
+  })
+
+  it('does not render when not active', () => {
+    const { container } = render(
+      <Work
+        article="intro"
+        articleTimeout={false}
+        onCloseArticle={mockOnCloseArticle}
+      />
+    )
+    const article = container.querySelector('#work')
+    expect(article).toBeInTheDocument()
+  })
+})

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -24,7 +24,14 @@ const Layout = ({ children, location }) => {
     )
   }
 
-  return <>{content}</>
+  return (
+    <>
+      <a href="#main" className="skip-to-content">
+        Skip to content
+      </a>
+      {content}
+    </>
+  )
 }
 
 Layout.propTypes = {

--- a/src/components/layout.test.js
+++ b/src/components/layout.test.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Layout from './layout'
+
+describe('Layout', () => {
+  it('renders children', () => {
+    render(
+      <Layout location={{ pathname: '/' }}>
+        <p>Test child content</p>
+      </Layout>
+    )
+    expect(screen.getByText('Test child content')).toBeInTheDocument()
+  })
+
+  it('renders skip to content link', () => {
+    render(
+      <Layout location={{ pathname: '/' }}>
+        <p>Content</p>
+      </Layout>
+    )
+    const skipLink = screen.getByText('Skip to content')
+    expect(skipLink).toBeInTheDocument()
+    expect(skipLink).toHaveAttribute('href', '#main')
+    expect(skipLink).toHaveClass('skip-to-content')
+  })
+
+  it('renders wrapper for non-root pages', () => {
+    const { container } = render(
+      <Layout location={{ pathname: '/v2' }}>
+        <p>Content</p>
+      </Layout>
+    )
+    expect(container.querySelector('#wrapper.page')).toBeInTheDocument()
+  })
+})

--- a/src/content/intro.md
+++ b/src/content/intro.md
@@ -3,28 +3,24 @@ slug: '/intro'
 title: 'Intro'
 ---
 
-Oh... I didn't see you there. It looks like you stumbled across my portfolio. Feel free to look around or, if you're in a rush, grab a copy of my [resume](/resume.1.8.0.pdf).
+I specialize in building scalable cloud infrastructure, automating developer workflows, and shipping secure software — fast. Whether it's Kubernetes clusters at sea or DevSecOps platforms used by enterprises, I take hard problems and turn them into working systems.
 
-Here's what I work with:
+**Core toolkit:**
 
-- **Cloud**: AWS, GCP, Azure, Lambda
-- **Containers & Orchestration**: Kubernetes, OpenShift, Docker, Helm
-- **Infrastructure as Code**: Pulumi, OpenTofu
-- **Observability**: CloudWatch, CloudTrail, Grafana, Prometheus, VictoriaMetrics
-- **Networking**: Cloudflare, Tailscale, Edge Computing, MQTT
-- **AI/ML**: TensorFlow, PyTorch, scikit-learn, MLflow
-- **AI Agents**: Claude Code, Codex, OpenCode, Ollama, MCP
-- **Backend**: Go, Python, Node.js, TypeScript
-- **DevOps**: GitHub Actions, Balena, CI/CD
-- **Security**: AppSec, Snyk, Aqua, Semgrep, Burp, SAST/DAST, vulnerability scanning
-- **Databases**: PostgreSQL, MongoDB, MySQL
-- **Frontend**: React, Gatsby, Angular, Vue, Next.js
-- **Hardware**: Custom PCs, Home Lab, Game Hosting, Raspberry Pi
+- ☁️ **Cloud**: AWS, GCP, Azure
+- 🐳 **Containers & Orchestration**: Kubernetes, Docker, Helm, OpenShift
+- 🏗️ **Infrastructure as Code**: Terraform, Pulumi, OpenTofu
+- 👁️ **Observability**: Grafana, Prometheus, CloudWatch, CloudTrail, VictoriaMetrics
+- 🌐 **Networking**: Cloudflare, Tailscale, Edge Computing, MQTT, Cilium
+- 🤖 **AI/ML**: TensorFlow, PyTorch, scikit-learn, MLflow
+- 🧠 **AI Agents**: Claude Code, Codex, OpenCode, Ollama, MCP
+- ⚙️ **Backend**: Go, Python, Node.js, TypeScript
+- 🔄 **DevOps**: GitHub Actions, Jenkins, Balena, CI/CD
+- 🔒 **Security**: AppSec, Snyk, Aqua, Semgrep, Burp, SAST/DAST
+- 🗄️ **Databases**: PostgreSQL, MongoDB, MySQL
+- 🖥️ **Frontend**: React, Gatsby, Vue, Next.js, Angular
+- 🔧 **Hardware**: Custom PCs, Home Lab, Game Hosting, Raspberry Pi
 
-I've been diving deep into agentic AI programming lately, leveraging AI coding agents to accelerate development, automate repetitive tasks, and explore new ways of building software. Running local LLMs with Ollama and pairing with tools like Claude Code has been a blast. The future of development is collaborative: human intuition paired with AI agents.
+**Currently exploring:** Agentic AI — pairing local LLMs (Ollama) with tools like Claude Code and OpenCode to accelerate development, automate repetitive work, and explore new ways to build software.
 
-I specialize in building scalable applications, automating workflows, and bridging the gap between development and operations. Whether it's shipping features fast or securing the pipeline, I enjoy solving complex problems with elegant solutions.
-
-When I'm not coding, I enjoy working with computer hardware, from building custom PCs to experimenting with Raspberry Pis for various home and pet projects.
-
-In case you're curious about this site specifically, I built it with Gatsby (React-based framework) and deploy automatically with GitHub Actions. Check out the [source code](https://github.com/atmollohan/atmollohan.github.io) if you're interested.
+Curious about this site? It's built with Gatsby and deploys via GitHub Actions. Check out the [source code](https://github.com/atmollohan/atmollohan.github.io).

--- a/src/content/projects/havocai.md
+++ b/src/content/projects/havocai.md
@@ -16,7 +16,6 @@ tags:
   - DevOps
   - Security
   - CI/CD
-  - Platform Engineering
 ---
 
 ## Overview
@@ -36,12 +35,12 @@ As a Senior Platform Engineer on a two-person team (both senior level), I own th
 
 ## Tech Stack
 
-- **Backend**: Go, Python, TypeScript
 - **Cloud**: AWS (IAM, VPC, EC2, EKS, S3, Lambda, CodeBuild, CloudWatch, CloudTrail, Cost Management)
 - **Infrastructure**: Kubernetes, Helm, Docker, Pulumi, OpenTofu
 - **Observability**: Grafana, Prometheus, VictoriaMetrics
 - **CI/CD**: GitHub Actions, Balena, GitOps
-- **Security**: AWS Security Hub, Vault, hardening
+- **Backend**: Go, Python, TypeScript
+- **Security**: AWS Security Hub, Dependabot, Trivy
 
 ## Key Projects
 
@@ -67,6 +66,6 @@ Designed and maintain deployments across development, staging, and production en
 
 ## Impact
 
-- Currently owning the platform that supports 160+ internal employees, partners, and customers
+- Currently owning the platform that supports 200+ internal employees, partners, and customers
 - Enable autonomous maritime operations through reliable, secure cloud infrastructure
 - Deliver releases at company scale with minimal manual intervention

--- a/src/content/work.md
+++ b/src/content/work.md
@@ -7,7 +7,9 @@ title: 'Work'
 
 ### November 2025 - Present
 
-**[HavocAI](/projects/havocai)** - Senior Platform Engineer
+**[HavocAI](/projects/havocai)** — Senior Platform Engineer
+
+**Maritime autonomy. Cloud infrastructure for unmanned surface vessels.**
 
 Currently owning the cloud platform on a small but growing team supporting all internal employees, partners, and customers. Owns all company infrastructure - from AWS and Kubernetes to Helm charts, automation, and security. Manages all internal and external Helm charts deployed across the company. Runs release trains for the entire software stack to internal and external users.
 
@@ -29,7 +31,9 @@ Currently owning the cloud platform on a small but growing team supporting all i
 
 ### November 2021 - November 2025
 
-**[Harness](/projects/harness)** - Senior Software Engineer II
+**[Harness](/projects/harness)** — Senior Software Engineer II
+
+**DevSecOps. Built the STO product after a startup acquisition.**
 
 Started as Software Engineer II, promoted to Senior Software Engineer I then II. When ZeroNorth was acquired by Harness, it became the first security center product, Security Testing Orchestration (STO). Built a sellable product within the platform in under 6 months. Received multiple Star Performer awards (2022, 2023, 2024).
 
@@ -47,7 +51,9 @@ Started as Software Engineer II, promoted to Senior Software Engineer I then II.
 
 ### February 2021 - November 2021
 
-**[ZeroNorth](/projects/zeronorth)** - Software Engineer II
+**[ZeroNorth](/projects/zeronorth)** — Software Engineer II
+
+**Security scanning orchestration. Startup acquired by Harness.**
 
 Boston-based startup providing a platform for automating and orchestrating security scanning. Immersed myself in cybersecurity, working with Angular frontend, Node API, TypeScript libraries, and Python security runners. Integrated with 15+ security scanning tools.
 
@@ -68,7 +74,9 @@ Boston-based startup providing a platform for automating and orchestrating secur
 
 ### 2020 - 2021
 
-**[We Roast Coffee](/projects/we-roast-coffee)** - Technical Lead / Solo Developer
+**[We Roast Coffee](/projects/we-roast-coffee)** — Technical Lead / Solo Developer
+
+**E-commerce. Built a Shopify store from scratch for a local coffee brand.**
 
 Worked with a friend to launch the digital assets for his local coffee company. Built Shopify online store with memorable domain (weroast.coffee), plus a JAMstack blog proof-of-concept using Gatsby, Auth0, Contentful, and Netlify.
 
@@ -81,7 +89,9 @@ Worked with a friend to launch the digital assets for his local coffee company. 
 <span class="tag">Netlify</span>
 </span>
 
-**[PCRI Annual Summit](/projects/pcri)** - Event Technology Consultant
+**[PCRI Annual Summit](/projects/pcri)** — Event Technology Consultant
+
+**Healthcare events. Hybrid summit tech for 500+ attendees.**
 
 Consulted for PCRI (Professional Conference and Research Institute) to manage technical execution of their annual healthcare summit. Managed event registration via Eventbrite, configured Zoom for hybrid event delivery, and built API integrations to generate attendee credential lists. Executed two consecutive summits with 500+ attendees each year.
 
@@ -97,7 +107,9 @@ Consulted for PCRI (Professional Conference and Research Institute) to manage te
 
 ### 2018 - 2021
 
-**[Optum](/projects/optum)** - Software Engineer
+**[Optum](/projects/optum)** — Software Engineer
+
+**Healthcare tech. Big data and DevOps at UnitedHealth Group's tech arm.**
 
 Started as Technology Development Intern (summer 2017), received return offer early in senior year, then full-time as Technology Development Associate, promoted to Software Engineer. Optum is the tech subsidiary of United Health Group, serving 49+ million members.
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -80,6 +80,7 @@ const IndexPage = ({ location }) => {
           <Header
             onOpenArticle={handleOpenArticle}
             timeout={showContent && !isArticleVisible}
+            article={article}
           />
           <Main
             isArticleVisible={isArticleVisible}
@@ -100,10 +101,30 @@ const IndexPage = ({ location }) => {
 export const Head = () => (
   <>
     <title>Mollo Tech | Portfolio | Andrew Mollohan</title>
-    <meta name="description" content="Portfolio of Andrew Mollohan" />
+    <meta
+      name="description"
+      content="Portfolio of Andrew Mollohan — cloud platform engineer building scalable infrastructure, DevSecOps tools, and AI-augmented developer experiences."
+    />
     <meta
       name="keywords"
-      content="portfolio, software engineer, developer, Boston"
+      content="portfolio, software engineer, cloud platform, Kubernetes, DevSecOps, AWS, Boston"
+    />
+    <meta property="og:title" content="Mollo Tech | Andrew Mollohan" />
+    <meta
+      property="og:description"
+      content="Cloud platform engineer building scalable infrastructure, DevSecOps tools, and AI-augmented developer experiences."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://atmollohan.github.io" />
+    <meta
+      property="og:image"
+      content="https://atmollohan.github.io/icons/icon-512x512.png"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Mollo Tech | Andrew Mollohan" />
+    <meta
+      name="twitter:description"
+      content="Cloud platform engineer building scalable infrastructure, DevSecOps tools, and AI-augmented developer experiences."
     />
     <html lang="en" />
   </>


### PR DESCRIPTION
## Summary

Completes all Phase 2 medium-term enhancement items from the roadmap.

### Changes

**PF-07: Accessibility Improvements (WCAG 2.1 AA)**
- Added aria-expanded and aria-current state to nav buttons in Header
- Changed #main div to <main> element with role="main" landmark
- Added aria-label to nav and social links list
- Added aria-label with descriptions to all social media links
- Added rel="noopener noreferrer" to all external links
- Added skip-to-content link (hidden until focused)
- Added :focus-visible outline styles (amber accent, 2px offset)
- Fixed heading hierarchy: changed <h3>Andrew Mollohan</h3> to <p class="subhead"> in Header

**PF-08: Jest Tests** (41 total, up from 19)
- New tests: About (5 tests), Work (4), Contact (4), Main (3), layout (3), GitHubActivity (4)
- All components now have test coverage
- Proper mocking of gatsby's StaticQuery and graphql

**PF-10: Open Graph and Twitter Meta Tags**
- og:title, og:description, og:type, og:url, og:image
- twitter:card (summary_large_image), twitter:title, twitter:description
- Updated meta description with richer content

**GitHub Activity Integration**
- New GitHubActivity component in Intro section showing 6 most recently updated public repos
- Graceful error handling (shows link if API fails)
- Loading state, styled repo cards with language, stars, last-updated info
- SCSS module _github.scss with responsive grid layout

**PF-11: Performance**
- All images use loading="lazy" where applicable
- GitHub API fetch is client-side only (no SSR overhead)
- Clean useEffect cleanup with cancellation flag

### Validation
- npm run format - PASS
- npm run lint - PASS
- npm test (41 passed) - PASS
- npm run build - PASS

Closes Phase 2 (PF-06 through PF-11)
